### PR TITLE
Add Go client implementation for multi-level cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AUR Cache Client (Go)
+
+This module provides a Go client for interacting with the
+[multi-level cache service](https://github.com/NikolayNN/multi-level-cache-service).
+It mirrors the functionality of the Java SDK.
+
+## Building and Testing
+
+Run the unit tests with:
+
+```bash
+go test ./...
+```
+
+## Example
+
+```go
+client := cache.New("http://localhost:8080")
+entries := []cache.CacheEntry[any]{
+    {CacheName: "users", Key: "1", Value: User{ID: 1, Name: "Alice"}},
+}
+err := client.PutAll(context.Background(), entries)
+```

--- a/cache/client.go
+++ b/cache/client.go
@@ -1,0 +1,150 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	endpointGetAll   = "/api/v1/cache/get_all"
+	endpointPutAll   = "/api/v1/cache/put_all"
+	endpointEvictAll = "/api/v1/cache/evict_all"
+)
+
+// Client is an HTTP client for the multi-level cache service.
+type Client struct {
+	baseURL       string
+	httpClient    *http.Client
+	gzipThreshold int
+	getTimeout    time.Duration
+	putTimeout    time.Duration
+	evictTimeout  time.Duration
+}
+
+// New creates a client with default options.
+func New(baseURL string) *Client {
+	return NewWithThreshold(baseURL, 0)
+}
+
+// NewWithThreshold creates a client with gzip threshold in bytes.
+func NewWithThreshold(baseURL string, gzipThreshold int) *Client {
+	return NewWithOptions(baseURL, gzipThreshold,
+		5*time.Second, 5*time.Second, 5*time.Second, &http.Client{})
+}
+
+// NewWithOptions creates a client with full customization.
+func NewWithOptions(baseURL string, gzipThreshold int,
+	getTimeout, putTimeout, evictTimeout time.Duration, httpClient *http.Client) *Client {
+	if strings.HasSuffix(baseURL, "/") {
+		baseURL = strings.TrimSuffix(baseURL, "/")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &Client{
+		baseURL:       baseURL,
+		httpClient:    httpClient,
+		gzipThreshold: gzipThreshold,
+		getTimeout:    getTimeout,
+		putTimeout:    putTimeout,
+		evictTimeout:  evictTimeout,
+	}
+}
+
+// GetAll fetches multiple entries from the cache and unmarshals the values into
+// the provided generic type.
+func GetAll[T any](c *Client, ctx context.Context, ids []CacheId) ([]CacheEntryHit[T], error) {
+	body, err := json.Marshal(ids)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.sendRequest(ctx, endpointGetAll, c.getTimeout, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var hits []CacheEntryHit[T]
+	if err := json.NewDecoder(resp.Body).Decode(&hits); err != nil {
+		return nil, err
+	}
+	return hits, nil
+}
+
+// PutAll stores multiple entries in the cache.
+func (c *Client) PutAll(ctx context.Context, entries []CacheEntry[any]) error {
+	body, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	resp, err := c.sendRequest(ctx, endpointPutAll, c.putTimeout, body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// EvictAll removes multiple entries from the cache.
+func (c *Client) EvictAll(ctx context.Context, ids []CacheId) error {
+	body, err := json.Marshal(ids)
+	if err != nil {
+		return err
+	}
+	resp, err := c.sendRequest(ctx, endpointEvictAll, c.evictTimeout, body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+func (c *Client) sendRequest(ctx context.Context, endpoint string, timeout time.Duration, body []byte) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	url := c.baseURL + endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	payload := body
+	if c.gzipThreshold > 0 && len(body) >= c.gzipThreshold {
+		req.Header.Set("Content-Encoding", "gzip")
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		if _, err := gw.Write(body); err != nil {
+			gw.Close()
+			return nil, err
+		}
+		if err := gw.Close(); err != nil {
+			return nil, err
+		}
+		payload = buf.Bytes()
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(payload))
+	req.ContentLength = int64(len(payload))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		data, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected response code %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+
+	return resp, nil
+}

--- a/cache/client_test.go
+++ b/cache/client_test.go
@@ -1,0 +1,100 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type User struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestGetAll(t *testing.T) {
+	expectedHits := []CacheEntryHit[User]{
+		{CacheName: "users", Key: "1", Value: User{ID: 1, Name: "Alice"}, Found: true},
+		{CacheName: "users", Key: "2", Value: User{}, Found: false},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointGetAll {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method: %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("content type: %s", ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		expectedBody := `[{"c":"users","k":"1"},{"c":"users","k":"2"}]`
+		if strings.TrimSpace(string(body)) != expectedBody {
+			t.Errorf("body = %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedHits)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	hits, err := GetAll[User](client, context.Background(), []CacheId{{"users", "1"}, {"users", "2"}})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !reflect.DeepEqual(hits, expectedHits) {
+		t.Errorf("expected %#v, got %#v", expectedHits, hits)
+	}
+}
+
+func TestPutAll(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointPutAll {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method: %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		expectedBody := `[{"c":"users","k":"1","v":{"id":1,"name":"Alice"}}]`
+		if strings.TrimSpace(string(body)) != expectedBody {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	entries := []CacheEntry[any]{{CacheName: "users", Key: "1", Value: User{1, "Alice"}}}
+	if err := client.PutAll(context.Background(), entries); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestEvictAll(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != endpointEvictAll {
+			t.Errorf("path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method: %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		expectedBody := `[{"c":"users","k":"1"}]`
+		if strings.TrimSpace(string(body)) != expectedBody {
+			t.Errorf("body = %s", body)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+	if err := client.EvictAll(context.Background(), []CacheId{{"users", "1"}}); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}

--- a/cache/models.go
+++ b/cache/models.go
@@ -1,0 +1,22 @@
+package cache
+
+// CacheId represents an identifier of an entry in a named cache.
+type CacheId struct {
+	CacheName string `json:"c"`
+	Key       string `json:"k"`
+}
+
+// CacheEntry represents a value stored in a named cache.
+type CacheEntry[T any] struct {
+	CacheName string `json:"c"`
+	Key       string `json:"k"`
+	Value     T      `json:"v"`
+}
+
+// CacheEntryHit represents the result of a cache fetch operation.
+type CacheEntryHit[T any] struct {
+	CacheName string `json:"c"`
+	Key       string `json:"k"`
+	Value     T      `json:"v"`
+	Found     bool   `json:"f"`
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module multi-level-cache-go-sdk
+
+go 1.21


### PR DESCRIPTION
## Summary
- implement cache client library with gzip and timeout support
- provide data models
- add unit tests using httptest
- include README with usage instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688898e3b828832c8425c546e9f084dc